### PR TITLE
Fix error with not existing primaryColorBrightness field in ThemeData

### DIFF
--- a/lib/widgets/hashtag_text_field.dart
+++ b/lib/widgets/hashtag_text_field.dart
@@ -692,7 +692,7 @@ class HashTagTextField extends StatefulWidget {
   ///
   /// This setting is only honored on iOS devices.
   ///
-  /// If unset, defaults to the brightness of [ThemeData.primaryColorBrightness].
+  /// If unset, defaults to the brightness of [ThemeData.brightness].
   final Brightness? keyboardAppearance;
 
   /// {@macro flutter.widgets.editableText.scrollPadding}
@@ -1199,7 +1199,7 @@ class _HashTagTextFieldState extends State<HashTagTextField>
         TextSelectionTheme.of(context);
     final TextStyle style = theme.textTheme.subtitle1!.merge(widget.basicStyle);
     final Brightness keyboardAppearance =
-        widget.keyboardAppearance ?? theme.primaryColorBrightness;
+        widget.keyboardAppearance ?? theme.brightness;
     final TextEditingController controller = _effectiveController;
     final FocusNode focusNode = _effectiveFocusNode;
     final List<TextInputFormatter> formatters = <TextInputFormatter>[


### PR DESCRIPTION
Flutter with version 3.10 removed ThemeData.primaryColorBrightness field. Changed occurence to ThemeData.brightness field, which should have similar value as old value.

Issue: 112